### PR TITLE
add keepandroidopen.org banner

### DIFF
--- a/activities.html
+++ b/activities.html
@@ -15,6 +15,7 @@
 
 <body class="dark">
   <!-- Barra superior -->
+  <script src="https://keepandroidopen.org/banner.js"></script>
   <header id="topbar">
     <span class="left">
       <img src="./assets/img/linuxupc-logo.png" alt="MENU">

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       </head>
     <body class="dark">
       <!-- Barra superior -->
+      <script src="https://keepandroidopen.org/banner.js"></script>
       <header id="topbar">
         <span class="left">
           <img src="./assets/img/linuxupc-logo.png" alt="MENU">


### PR DESCRIPTION
Add [Keep Android Open](keepandroidopen.org) banner to both the index and activities pages. 

<img width="1920" height="1223" alt="image" src="https://github.com/user-attachments/assets/dcb583c3-b604-49ea-be9b-a16a9aa90711" />

<img width="1920" height="2369" alt="image" src="https://github.com/user-attachments/assets/6fb2b0cb-b8f3-42ca-9e9d-972a9e8ca058" />
